### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: kenessajr/test-actions
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore